### PR TITLE
fix: skip model/API-key validation for oracle agent

### DIFF
--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -144,7 +144,7 @@ def resolve_agent_env(
     """Resolve agent environment: auto-inherit keys, provider vars, env_mapping."""
     agent_env = dict(agent_env or {})
     auto_inherit_env(agent_env)
-    if model:
+    if model and agent != "oracle":
         inject_vertex_credentials(agent_env, model)
         resolve_provider_env(agent_env, model, agent)
         # Validate required API key for the chosen model


### PR DESCRIPTION
## Summary

- Oracle agent runs `solution/solve.sh` and never calls an LLM, but `resolve_agent_env()` was validating API keys for the CLI's default model (`claude-haiku-4-5-20251001`)
- `bench eval create -a oracle` now works without `ANTHROPIC_API_KEY` set
- One-line change: skip the model validation block when `agent == "oracle"`

## Test plan

- [x] All 42 tests in `test_resolve_env_helpers.py` and `test_subscription_auth.py` pass
- [ ] Run `bench eval create -t <task> -a oracle` without `ANTHROPIC_API_KEY` — should succeed
- [ ] Run `bench eval create -t <task> -a claude-agent-acp` — API key validation still works as before