### PR TITLE
fix: Job.from_yaml dropping top-level scenes

### DIFF
--- a/plan/2026-04-26-issue-4-harbor-scenes-parsing.md
+++ b/plan/2026-04-26-issue-4-harbor-scenes-parsing.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-26
 **Issue:** [EYH0602/benchflow#4](https://github.com/EYH0602/benchflow/issues/4)
-**Status:** drafted, not yet executed
+**Status:** revised post `/plan-eng-review` 2026-04-26 — scope expanded with 9 review decisions baked in
 
 ## Problem
 
@@ -31,138 +31,219 @@ it via the scene-aware `Trial` path. Strictly additive — legacy single-turn YA
 
 ## Scope
 
-**In:**
-- Harbor YAML parsing in `_from_harbor_yaml`.
-- `JobConfig` shape (add `scenes` field).
-- `Job._run_single_task` branching.
-- Regression test in `tests/test_yaml_config.py`.
+**In (post-review, all decisions accepted):**
+- Harbor YAML parsing in `_from_harbor_yaml` — top-level `scenes:` block.
+- Native YAML parsing in `_from_native_yaml` — top-level `scenes:` block (decision 1A).
+- `JobConfig` shape — add `scenes: list[Scene] | None = None` field.
+- Unified `Job._run_single_task` `TrialConfig` construction (decision 2A — single call site, branch only on the `scenes` arg).
+- Promote `_parse_scene` / `_parse_role` / `_parse_turn` → `parse_scene` / `parse_role` / `parse_turn` in `trial_yaml.py` (decision 2B).
+- `parse_role` `model_name` fallback (decision 2C — `model = raw.get("model") or raw.get("model_name")`).
+- Harbor `_from_harbor_yaml` reads top-level singular `agent:` and top-level `model_name:` as fallbacks when `agents:` array is absent (TODO 1, in-PR).
+- Empty `scenes: []` emits a `logger.warning` and falls through to legacy (TODO 2, in-PR).
+- When `cfg.scenes` is non-empty, derive `JobConfig.agent` / `JobConfig.model` from the first role of the first scene so `summary.json` reflects what actually ran (TODO 3, in-PR).
+- Tests in `tests/test_yaml_config.py` and the `parse_role` test file — config-shape, behavior, literal issue #4 YAML, native parity, summary fidelity.
 
 **Out:**
-- `_from_native_yaml` (already covered indirectly via the per-trial `trial_yaml` loader).
 - No changes to `Trial`, `_scene.py`, `TrialConfig`, or `SDK.run`.
-- No `model_name` fallback inside scene roles for now — defer unless requested. Existing
-  `model:` key works as-is for the issue's repro YAML.
+- No real-`Trial`-execution integration test — covered by existing `tests/test_scene_outbox_trial.py`.
 
 ## Files
 
-- `src/benchflow/job.py` — add field, parse, branch.
-- `tests/test_yaml_config.py` — add regression test(s).
+- `src/benchflow/job.py` — `JobConfig.scenes`, scenes parsing in both loaders, top-level `agent:`/`model_name:` fallback, empty-scenes warning, summary-field derivation, unified `_run_single_task`.
+- `src/benchflow/trial_yaml.py` — rename `_parse_*` → `parse_*`; `model_name` fallback in `parse_role`.
+- `tests/test_yaml_config.py` — Harbor + native scenes parsing, behavior test for `_run_single_task`, issue #4 literal regression, additive guarantees, top-level singular-`agent:`/`model_name:` test, empty-scenes warning test, summary-field fidelity test.
+- `tests/test_trial_yaml.py` (or wherever `parse_role` is tested) — `model_name` fallback test.
 
 ## Steps
 
-### 1. Add `scenes` to `JobConfig` (`src/benchflow/job.py:153`)
+### 1. Promote `_parse_*` to public + `model_name` fallback (`src/benchflow/trial_yaml.py`) — decisions 2B, 2C
 
-- Import `Scene` from `benchflow.trial` at module top (lazy import inside method if circulars).
-- Add field: `scenes: list[Scene] | None = None`
-  - Default `None`, **not** `[]`, so we can distinguish "not specified" from "explicitly empty"
-    in the branch in step 3.
+- Rename `_parse_scene` → `parse_scene`, `_parse_role` → `parse_role`, `_parse_turn` → `parse_turn`. Update internal callers (one site at `trial_yaml.py:81`).
+- In `parse_role`, change `model=raw.get("model")` → `model = raw.get("model") or raw.get("model_name")`.
+- These functions are not in any `__all__` and not referenced by tests/external code (verified by grep) — rename is safe.
 
-### 2. Parse `scenes:` in `_from_harbor_yaml` (`src/benchflow/job.py:312-368`)
+### 2. Add `scenes` to `JobConfig` (`src/benchflow/job.py:153`)
 
-After existing parses (orchestrator, datasets, env), add:
+- Import `Scene` from `benchflow.trial` at module top (lazy import inside method if circulars surface).
+- Add field: `scenes: list[Scene] | None = None`. Default `None`, **not** `[]`, so we can distinguish "not specified" from "explicitly empty" — empty fires a warning per Step 4.
+
+### 3. Parse `scenes:` in both loaders — decision 1A
+
+In **`_from_harbor_yaml` (`src/benchflow/job.py:312-368`)** and **`_from_native_yaml` (`src/benchflow/job.py:281-310`)**:
 
 ```python
-from benchflow.trial_yaml import _parse_scene  # or import at module top
+from benchflow.trial_yaml import parse_scene
 scenes_raw = raw.get("scenes")
-scenes = [_parse_scene(s) for s in scenes_raw] if scenes_raw else None
+if scenes_raw is None:
+    scenes = None
+elif not scenes_raw:  # explicit empty list
+    logger.warning(
+        "scenes: [] is empty — falling through to legacy single-turn execution. "
+        "Remove the key entirely if that is the intent."
+    )
+    scenes = None
+else:
+    scenes = [parse_scene(s) for s in scenes_raw]
 ```
 
-Pass `scenes=scenes` into `JobConfig(...)`.
+Pass `scenes=scenes` into the `JobConfig(...)` call in each loader.
 
-### 3. Branch in `Job._run_single_task` (`src/benchflow/job.py:418-438`)
+### 4. Harbor top-level singular `agent:` / `model_name:` fallback (TODO 1)
 
-When `cfg.scenes` is truthy, build the trial config directly instead of via `from_legacy`:
+In `_from_harbor_yaml`, before reading `agents[]`:
 
 ```python
-from benchflow.trial import Trial, TrialConfig
+agents = raw.get("agents") or []
+agent_cfg = agents[0] if agents else {}
+agent_name = agent_cfg.get("name") or raw.get("agent", DEFAULT_AGENT)
+model_raw = agent_cfg.get("model_name") or raw.get("model_name") or raw.get("model")
+model = effective_model(agent_name, model_raw)
+```
 
-if cfg.scenes:
-    trial_config = TrialConfig(
-        task_path=task_dir,
-        scenes=cfg.scenes,
-        job_name=self._job_name,
-        jobs_dir=str(self._jobs_dir),
-        environment=cfg.environment,
-        sandbox_user=cfg.sandbox_user,
-        sandbox_locked_paths=cfg.sandbox_locked_paths,
-        sandbox_setup_timeout=cfg.sandbox_setup_timeout,
-        context_root=cfg.context_root,
-        agent_env=cfg.agent_env,
-        skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
-    )
-else:
-    trial_config = TrialConfig.from_legacy(
-        task_path=task_dir,
+This makes the issue #4 repro YAML (singular `agent: pi-acp` + top-level `model_name: vllm/...`) carry the user's intent into `JobConfig.agent` / `.model` instead of silently defaulting.
+
+### 5. Derive summary fields from scenes when present (TODO 3)
+
+After the `scenes` parse in both loaders, if `scenes` is non-empty, override the agent/model assigned to `JobConfig` so `summary.json` reflects what actually runs:
+
+```python
+if scenes and scenes[0].roles:
+    primary_role = scenes[0].roles[0]
+    agent_name = primary_role.agent
+    model = primary_role.model or model
+```
+
+This matches what `TrialConfig.primary_agent` / `primary_model` already do at execution time.
+
+### 6. Unified `Job._run_single_task` (`src/benchflow/job.py:418-438`) — decision 2A
+
+Replace the two-branch construction with a single `TrialConfig(...)` call that decides scenes inline:
+
+```python
+from benchflow.trial import Scene, Trial, TrialConfig
+
+resolved_skills = self._resolve_skills_dir(task_dir, cfg.skills_dir)
+scenes = cfg.scenes or [
+    Scene.single(
         agent=cfg.agent,
         model=cfg.model,
         prompts=cfg.prompts,
-        agent_env=cfg.agent_env,
-        job_name=self._job_name,
-        jobs_dir=str(self._jobs_dir),
-        environment=cfg.environment,
-        skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
-        sandbox_user=cfg.sandbox_user,
-        sandbox_locked_paths=cfg.sandbox_locked_paths,
-        sandbox_setup_timeout=cfg.sandbox_setup_timeout,
-        context_root=cfg.context_root,
+        skills_dir=resolved_skills,
     )
+]
+trial_config = TrialConfig(
+    task_path=task_dir,
+    scenes=scenes,
+    job_name=self._job_name,
+    jobs_dir=str(self._jobs_dir),
+    environment=cfg.environment,
+    sandbox_user=cfg.sandbox_user,
+    sandbox_locked_paths=cfg.sandbox_locked_paths,
+    sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+    context_root=cfg.context_root,
+    agent_env=cfg.agent_env,
+    skills_dir=resolved_skills,
+    # Legacy mirror fields kept for any consumers reading them off TrialConfig:
+    agent=cfg.agent,
+    model=cfg.model,
+    prompts=cfg.prompts,
+)
+trial = await Trial.create(trial_config)
+return await trial.run()
 ```
 
-Leave `_run_single_task_legacy` untouched — it's the test-mock SDK path, not relevant for
-scene-aware flows.
+Leave `_run_single_task_legacy` untouched — it's the test-mock SDK path, not relevant for scene-aware flows.
 
-### 4. Regression test (`tests/test_yaml_config.py`)
+### 7. Tests
 
-**Test A — `test_harbor_yaml_parses_top_level_scenes`:**
-- tmp_path Harbor YAML with `agents:` + `datasets:` + `scenes:` (one scene, one role, one turn).
-- `Job.from_yaml(...)`.
-- Assert `job._config.scenes is not None`.
-- Assert `len(job._config.scenes) == 1`.
-- Assert `job._config.scenes[0].name`, `roles[0].agent`, `turns[0].prompt` match the YAML.
-- Docstring: `"""Guards the fix from PR #<n> against the regression where Harbor YAML silently dropped scenes (issue #4)."""`
+#### `tests/test_yaml_config.py`
 
-**Test B — `test_harbor_yaml_without_scenes_unchanged`:**
-- Existing harbor YAML (no `scenes:`).
-- Assert `job._config.scenes is None`.
-- Locks in the additive guarantee — legacy YAMLs see no behavior change.
+**Test A — `test_harbor_yaml_parses_issue_4_repro` (decision 3B, regression):**
+- Fixture YAML = the literal repro from issue #4 (2 scenes: `build-skill` + `answer`, role-level `model:`, second turn lacks `prompt:`).
+- Assert `job._config.scenes` is a 2-element list.
+- Assert `scenes[0].name == "build-skill"`, `scenes[0].roles[0].agent == "pi-acp"`, `scenes[0].roles[0].model == "vllm/Qwen/Qwen3.6-27B"`, `scenes[0].turns[0].prompt == "build the skill ..."`.
+- Assert `scenes[1].name == "answer"`, `scenes[1].turns[0].prompt is None` (default-prompt path).
+- Docstring: `"""Guards the fix from PR #<n> against the silent-scenes-drop regression in issue #4 — mirrors the literal repro YAML."""`
+
+**Test B — `test_harbor_yaml_branch_passes_scenes_to_trial` (decision 3A, behavior):**
+- `monkeypatch.setattr(benchflow.trial.Trial, "create", capturing_mock)` where the mock records its `TrialConfig` argument and returns a fake Trial whose `.run()` is a no-op.
+- Build a Job from a Harbor scenes YAML, call `_run_single_task(task_dir, cfg)`.
+- Assert the captured `TrialConfig.scenes == cfg.scenes` (same scene names, role count, turn count).
+- This is the test that would have failed pre-fix.
+
+**Test C — `test_harbor_yaml_without_scenes_unchanged`:**
+- Existing harbor YAML (no `scenes:`). Assert `_config.scenes is None`.
+
+**Test D — `test_native_yaml_parses_top_level_scenes` (decision 1A):**
+- Native YAML with `scenes:` block. Assert `_config.scenes` populated.
+
+**Test E — `test_native_yaml_without_scenes_unchanged` (decision 1A):**
+- Native YAML, no `scenes:`. Assert `_config.scenes is None`.
+
+**Test F — `test_harbor_yaml_top_level_singular_agent_and_model_name` (TODO 1):**
+- YAML with `agent: pi-acp` (singular), `model_name: vllm/Qwen/Qwen3.6-27B` (top-level), no `agents:` array.
+- Assert `_config.agent == "pi-acp"`, `_config.model == "vllm/Qwen/Qwen3.6-27B"`.
+
+**Test G — `test_harbor_yaml_empty_scenes_warns` (TODO 2):**
+- YAML with `scenes: []`. Assert `_config.scenes is None` AND a warning was logged (use `caplog`).
+
+**Test H — `test_harbor_yaml_summary_fields_match_first_scene_role` (TODO 3):**
+- YAML with `agents: [{name: x, model_name: y}]` AND `scenes: [{roles: [{name: r, agent: real-agent, model: real-model}], ...}]`.
+- Assert `_config.agent == "real-agent"`, `_config.model == "real-model"` (scene roles win for summary).
+
+#### `tests/test_trial_yaml.py` (or co-located with parse helpers)
+
+**Test I — `test_parse_role_model_name_fallback` (decision 2C):**
+- `parse_role({"name": "r", "agent": "a", "model_name": "m"})` → `Role(model="m")`.
+- `parse_role({"name": "r", "agent": "a", "model": "m"})` → `Role(model="m")` (existing path, smoke).
+- `parse_role({"name": "r", "agent": "a"})` → `Role(model=None)`.
 
 ## Risks / open questions
 
-- **`Scene` symbol collision.** Two classes named `Scene`: `trial.py` (dataclass, the right one)
-  and `_scene.py` (runtime). All imports must be `from benchflow.trial import Scene`. Test
-  assertions should reference `benchflow.trial.Scene` to avoid future drift.
+- **`Scene` symbol collision.** Two classes named `Scene`: `trial.py` (dataclass, the right one) and `_scene.py` (runtime). All imports must be `from benchflow.trial import Scene`. Test assertions should reference `benchflow.trial.Scene` to avoid future drift.
 
-- **`skills_dir` precedence.** `JobConfig.skills_dir` (job-level) and `Scene.skills_dir`
-  (per-scene) coexist. Today `from_legacy` injects job-level into the synthesized single
-  Scene. With explicit `scenes:`, per-scene `skills_dir` (parsed by `_parse_scene`) wins;
-  job-level still flows through `TrialConfig.skills_dir` for trial-wide injection. Matches
-  existing `trial_yaml` semantics — no special handling needed.
+- **`skills_dir` precedence.** `JobConfig.skills_dir` (job-level) and `Scene.skills_dir` (per-scene) coexist. Today `from_legacy` injects job-level into the synthesized single Scene. With explicit `scenes:`, per-scene `skills_dir` (parsed by `parse_scene`) wins; job-level still flows through `TrialConfig.skills_dir` for trial-wide injection. Matches existing `trial_yaml` semantics — no special handling needed.
 
-- **`agent_env` plumbing.** Harbor's top-level `environment.env` populates `JobConfig.agent_env`.
-  Scene roles may also carry `env:`. Both flow through `TrialConfig` already — no change.
+- **`agent_env` plumbing.** Harbor's top-level `environment.env` populates `JobConfig.agent_env`. Scene roles may also carry `env:`. Both flow through `TrialConfig` already — no change.
 
-- **Empty `scenes: []`.** A truthy-but-empty list would currently fall into the `if cfg.scenes:`
-  false branch (because `bool([]) is False`), so we'd silently degrade to `from_legacy`. That
-  matches user intent ("you wrote nothing, you got default"). No special test required.
+- **Empty `scenes: []`.** Per TODO 2 (in-PR), this now logs a warning and falls through to legacy execution. Test G covers this.
+
+- **Public-API surface for `parse_*`.** Renaming drops the underscore; downstream code that imported `_parse_scene` would break. `grep -r "_parse_scene\|_parse_role\|_parse_turn"` showed only the internal `trial_yaml.py:81` reference. Safe.
 
 ## Verification
 
 ```bash
-.venv/bin/python -m pytest tests/test_yaml_config.py -v
-.venv/bin/ty check src/benchflow/job.py
-ruff check src/benchflow/job.py tests/test_yaml_config.py
+.venv/bin/python -m pytest tests/test_yaml_config.py tests/test_trial_yaml.py -v
+.venv/bin/ty check src/benchflow/job.py src/benchflow/trial_yaml.py
+ruff check src/benchflow/job.py src/benchflow/trial_yaml.py tests/test_yaml_config.py
 ```
 
-Plus the issue's original repro: `j._config.scenes` should now be a 2-element list, not absent.
+Plus the issue's original repro: `j._config.scenes` is a 2-element list, `j._config.agent == "pi-acp"`, `j._config.model == "vllm/Qwen/Qwen3.6-27B"`.
 
-## Estimated diff
+## Estimated diff (revised)
 
-~25 lines `job.py`, ~30 lines test. No deletions. No public API removals.
+- `src/benchflow/job.py`: ~50 lines (scenes parsing in 2 loaders, summary derivation, top-level singular fallback, unified `_run_single_task`).
+- `src/benchflow/trial_yaml.py`: ~5 lines (rename + `model_name` fallback).
+- `tests/test_yaml_config.py`: ~120 lines (Tests A–H).
+- `tests/test_trial_yaml.py`: ~20 lines (Test I).
 
-## Out of scope (follow-ups, if desired)
+Total: ~195 lines added, ~15 removed (the dual-branch `_run_single_task` collapses).
 
-- `model_name` fallback in `_parse_role` for Harbor convention consistency.
-- A warning/error path when both top-level `agents:` and `scenes:` define conflicting
-  agent identities (today: scene roles silently override).
-- Native YAML (`_from_native_yaml`) parity — does it need a `scenes:` shortcut, or does the
-  existing per-trial `trial_yaml` loader cover the use case?
+## Out of scope (deliberate)
+
+- Real `Trial.run` integration test for scenes — covered by `tests/test_scene_outbox_trial.py`.
+- Conflict warning when both top-level `agents:` and scene roles define agents with different identities — TODO 3 already prefers scene roles for summary; explicit conflict detection is a future tightening.
+- Refactoring `_run_single_task_legacy` to also support scenes — the legacy path exists only for test-mock SDK compat; real execution uses the unified path.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | bug fix; CEO review optional |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | skipped — 25-LOC bug fix, not strategy |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 6 issues found, all 9 decisions captured; 1 critical gap (empty-scenes silent fall-through) closed by in-PR warning |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | not applicable — library bug fix |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | not applicable |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG CLEARED — ready to implement. Plan body has been revised to absorb all 9 review decisions (1A, 2A, 2B, 2C, 3A, 3B, TODOs 1/2/3 — all in-PR).

--- a/plan/2026-04-26-issue-4-harbor-scenes-parsing.md
+++ b/plan/2026-04-26-issue-4-harbor-scenes-parsing.md
@@ -1,0 +1,168 @@
+# Plan: Harbor `Job.from_yaml` scenes parsing (issue #4)
+
+**Date:** 2026-04-26
+**Issue:** [EYH0602/benchflow#4](https://github.com/EYH0602/benchflow/issues/4)
+**Status:** drafted, not yet executed
+
+## Problem
+
+`Job.from_yaml(...)` (Harbor-shape branch, `_from_harbor_yaml`) silently drops a top-level
+`scenes:` block. Verified empirically:
+
+```text
+JobConfig dataclass fields: [..., 'context_root', 'exclude_tasks']  # no 'scenes'
+Has 'scenes' attr on JobConfig: False
+```
+
+Multi-turn intent vanishes; the run falls through to `TrialConfig.from_legacy(...)` and
+executes single-turn for every task in `datasets[].path`. No warning emitted.
+
+The scene-aware machinery already exists everywhere else:
+- `src/benchflow/_scene.py` — runtime
+- `src/benchflow/trial.py` — `Role`, `Turn`, `Scene` dataclasses + `TrialConfig.scenes`
+- `src/benchflow/trial_yaml.py:80` — per-trial loader handles `if "scenes" in raw:`
+
+The Harbor `Job` loader is the only layer not taught about scenes.
+
+## Goal
+
+Teach `Job._from_harbor_yaml` to parse `scenes:`, plumb it through `JobConfig`, and execute
+it via the scene-aware `Trial` path. Strictly additive — legacy single-turn YAMLs unchanged.
+
+## Scope
+
+**In:**
+- Harbor YAML parsing in `_from_harbor_yaml`.
+- `JobConfig` shape (add `scenes` field).
+- `Job._run_single_task` branching.
+- Regression test in `tests/test_yaml_config.py`.
+
+**Out:**
+- `_from_native_yaml` (already covered indirectly via the per-trial `trial_yaml` loader).
+- No changes to `Trial`, `_scene.py`, `TrialConfig`, or `SDK.run`.
+- No `model_name` fallback inside scene roles for now — defer unless requested. Existing
+  `model:` key works as-is for the issue's repro YAML.
+
+## Files
+
+- `src/benchflow/job.py` — add field, parse, branch.
+- `tests/test_yaml_config.py` — add regression test(s).
+
+## Steps
+
+### 1. Add `scenes` to `JobConfig` (`src/benchflow/job.py:153`)
+
+- Import `Scene` from `benchflow.trial` at module top (lazy import inside method if circulars).
+- Add field: `scenes: list[Scene] | None = None`
+  - Default `None`, **not** `[]`, so we can distinguish "not specified" from "explicitly empty"
+    in the branch in step 3.
+
+### 2. Parse `scenes:` in `_from_harbor_yaml` (`src/benchflow/job.py:312-368`)
+
+After existing parses (orchestrator, datasets, env), add:
+
+```python
+from benchflow.trial_yaml import _parse_scene  # or import at module top
+scenes_raw = raw.get("scenes")
+scenes = [_parse_scene(s) for s in scenes_raw] if scenes_raw else None
+```
+
+Pass `scenes=scenes` into `JobConfig(...)`.
+
+### 3. Branch in `Job._run_single_task` (`src/benchflow/job.py:418-438`)
+
+When `cfg.scenes` is truthy, build the trial config directly instead of via `from_legacy`:
+
+```python
+from benchflow.trial import Trial, TrialConfig
+
+if cfg.scenes:
+    trial_config = TrialConfig(
+        task_path=task_dir,
+        scenes=cfg.scenes,
+        job_name=self._job_name,
+        jobs_dir=str(self._jobs_dir),
+        environment=cfg.environment,
+        sandbox_user=cfg.sandbox_user,
+        sandbox_locked_paths=cfg.sandbox_locked_paths,
+        sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+        context_root=cfg.context_root,
+        agent_env=cfg.agent_env,
+        skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
+    )
+else:
+    trial_config = TrialConfig.from_legacy(
+        task_path=task_dir,
+        agent=cfg.agent,
+        model=cfg.model,
+        prompts=cfg.prompts,
+        agent_env=cfg.agent_env,
+        job_name=self._job_name,
+        jobs_dir=str(self._jobs_dir),
+        environment=cfg.environment,
+        skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
+        sandbox_user=cfg.sandbox_user,
+        sandbox_locked_paths=cfg.sandbox_locked_paths,
+        sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+        context_root=cfg.context_root,
+    )
+```
+
+Leave `_run_single_task_legacy` untouched — it's the test-mock SDK path, not relevant for
+scene-aware flows.
+
+### 4. Regression test (`tests/test_yaml_config.py`)
+
+**Test A — `test_harbor_yaml_parses_top_level_scenes`:**
+- tmp_path Harbor YAML with `agents:` + `datasets:` + `scenes:` (one scene, one role, one turn).
+- `Job.from_yaml(...)`.
+- Assert `job._config.scenes is not None`.
+- Assert `len(job._config.scenes) == 1`.
+- Assert `job._config.scenes[0].name`, `roles[0].agent`, `turns[0].prompt` match the YAML.
+- Docstring: `"""Guards the fix from PR #<n> against the regression where Harbor YAML silently dropped scenes (issue #4)."""`
+
+**Test B — `test_harbor_yaml_without_scenes_unchanged`:**
+- Existing harbor YAML (no `scenes:`).
+- Assert `job._config.scenes is None`.
+- Locks in the additive guarantee — legacy YAMLs see no behavior change.
+
+## Risks / open questions
+
+- **`Scene` symbol collision.** Two classes named `Scene`: `trial.py` (dataclass, the right one)
+  and `_scene.py` (runtime). All imports must be `from benchflow.trial import Scene`. Test
+  assertions should reference `benchflow.trial.Scene` to avoid future drift.
+
+- **`skills_dir` precedence.** `JobConfig.skills_dir` (job-level) and `Scene.skills_dir`
+  (per-scene) coexist. Today `from_legacy` injects job-level into the synthesized single
+  Scene. With explicit `scenes:`, per-scene `skills_dir` (parsed by `_parse_scene`) wins;
+  job-level still flows through `TrialConfig.skills_dir` for trial-wide injection. Matches
+  existing `trial_yaml` semantics — no special handling needed.
+
+- **`agent_env` plumbing.** Harbor's top-level `environment.env` populates `JobConfig.agent_env`.
+  Scene roles may also carry `env:`. Both flow through `TrialConfig` already — no change.
+
+- **Empty `scenes: []`.** A truthy-but-empty list would currently fall into the `if cfg.scenes:`
+  false branch (because `bool([]) is False`), so we'd silently degrade to `from_legacy`. That
+  matches user intent ("you wrote nothing, you got default"). No special test required.
+
+## Verification
+
+```bash
+.venv/bin/python -m pytest tests/test_yaml_config.py -v
+.venv/bin/ty check src/benchflow/job.py
+ruff check src/benchflow/job.py tests/test_yaml_config.py
+```
+
+Plus the issue's original repro: `j._config.scenes` should now be a 2-element list, not absent.
+
+## Estimated diff
+
+~25 lines `job.py`, ~30 lines test. No deletions. No public API removals.
+
+## Out of scope (follow-ups, if desired)
+
+- `model_name` fallback in `_parse_role` for Harbor convention consistency.
+- A warning/error path when both top-level `agents:` and `scenes:` define conflicting
+  agent identities (today: scene roles silently override).
+- Native YAML (`_from_native_yaml`) parity — does it need a `scenes:` shortcut, or does the
+  existing per-trial `trial_yaml` loader cover the use case?

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -169,7 +169,8 @@ class JobConfig:
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
     # None = unspecified (legacy single-turn execution); non-empty list = multi-scene flow.
-    # Empty list `[]` is rejected at parse time (warning, treated as None).
+    # Empty list `[]` from YAML is coerced to None with a warning in _from_*_yaml; the
+    # dataclass itself does not enforce that — direct construction with [] is accepted.
     scenes: list[Scene] | None = None
 
     def __post_init__(self):
@@ -301,7 +302,7 @@ class Job:
         agent_name = raw.get("agent", DEFAULT_AGENT)
         model = effective_model(agent_name, raw.get("model"))
 
-        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        # scenes_raw: None → legacy single-turn, [] → warn-then-legacy, list → multi-scene.
         scenes_raw = raw.get("scenes")
         scenes: list[Scene] | None
         if scenes_raw is None:
@@ -316,10 +317,13 @@ class Job:
             scenes = [parse_scene(s) for s in scenes_raw]
 
         # Derive summary fields from scenes when present so summary.json reflects what runs.
+        # Re-resolve through effective_model so the oracle short-circuit applies to the
+        # scene's agent (not the top-level one) — otherwise a non-oracle top-level + oracle
+        # role would leak DEFAULT_MODEL into JobConfig and disagree with result.json.
         if scenes and scenes[0].roles:
             primary_role = scenes[0].roles[0]
             agent_name = primary_role.agent
-            model = primary_role.model or model
+            model = effective_model(agent_name, primary_role.model)
 
         config = JobConfig(
             agent=agent_name,
@@ -345,7 +349,8 @@ class Job:
 
         # Agent — accept both Harbor-canonical agents[].name/model_name and the
         # singular top-level fallback (issue #4: `agent: pi-acp` + top-level
-        # `model_name: vllm/...`). agents[].* wins when both are present.
+        # `model_name: vllm/...`). agents[].* wins when truthy; falsy values
+        # (missing key, empty string) fall through to top-level keys.
         agents = raw.get("agents") or []
         agent_cfg = agents[0] if agents else {}
         agent_name = agent_cfg.get("name") or raw.get("agent", DEFAULT_AGENT)
@@ -390,7 +395,7 @@ class Job:
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
-        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        # scenes_raw: None → legacy single-turn, [] → warn-then-legacy, list → multi-scene.
         scenes_raw = raw.get("scenes")
         scenes: list[Scene] | None
         if scenes_raw is None:
@@ -405,10 +410,11 @@ class Job:
             scenes = [parse_scene(s) for s in scenes_raw]
 
         # Derive summary fields from scenes when present so summary.json reflects what runs.
+        # See _from_native_yaml: must re-resolve through effective_model so oracle stays None.
         if scenes and scenes[0].roles:
             primary_role = scenes[0].roles[0]
             agent_name = primary_role.agent
-            model = primary_role.model or model
+            model = effective_model(agent_name, primary_role.model)
 
         config = JobConfig(
             agent=agent_name,

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -90,6 +90,7 @@ from benchflow._scoring import (
 )
 from benchflow.models import RunResult
 from benchflow.sdk import SDK
+from benchflow.trial import Scene
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,9 @@ class JobConfig:
     sandbox_setup_timeout: int = 120
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
+    # None = unspecified (legacy single-turn execution); non-empty list = multi-scene flow.
+    # Empty list `[]` is rejected at parse time (warning, treated as None).
+    scenes: list[Scene] | None = None
 
     def __post_init__(self):
         from benchflow.agents.registry import AGENTS
@@ -280,6 +284,8 @@ class Job:
     @classmethod
     def _from_native_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse benchflow-native YAML."""
+        from benchflow.trial_yaml import parse_scene
+
         tasks_dir = Path(raw["tasks_dir"])
         jobs_dir = Path(raw.get("jobs_dir", "jobs"))
 
@@ -293,9 +299,31 @@ class Job:
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
         agent_name = raw.get("agent", DEFAULT_AGENT)
+        model = effective_model(agent_name, raw.get("model"))
+
+        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        scenes_raw = raw.get("scenes")
+        scenes: list[Scene] | None
+        if scenes_raw is None:
+            scenes = None
+        elif not scenes_raw:
+            logger.warning(
+                "scenes: [] is empty — falling through to legacy single-turn execution. "
+                "Remove the key entirely if that is the intent."
+            )
+            scenes = None
+        else:
+            scenes = [parse_scene(s) for s in scenes_raw]
+
+        # Derive summary fields from scenes when present so summary.json reflects what runs.
+        if scenes and scenes[0].roles:
+            primary_role = scenes[0].roles[0]
+            agent_name = primary_role.agent
+            model = primary_role.model or model
+
         config = JobConfig(
             agent=agent_name,
-            model=effective_model(agent_name, raw.get("model")),
+            model=model,
             environment=raw.get("environment", "docker"),
             concurrency=raw.get("concurrency", 4),
             prompts=prompts,
@@ -306,19 +334,28 @@ class Job:
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
             exclude_tasks=exclude,
+            scenes=scenes,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
     @classmethod
     def _from_harbor_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse Harbor-compatible YAML."""
-        # Agent
-        agents = raw.get("agents", [{}])
-        agent_cfg = agents[0] if agents else {}
-        agent_name = agent_cfg.get("name", DEFAULT_AGENT)
+        from benchflow.trial_yaml import parse_scene
 
+        # Agent — accept both Harbor-canonical agents[].name/model_name and the
+        # singular top-level fallback (issue #4: `agent: pi-acp` + top-level
+        # `model_name: vllm/...`). agents[].* wins when both are present.
+        agents = raw.get("agents") or []
+        agent_cfg = agents[0] if agents else {}
+        agent_name = agent_cfg.get("name") or raw.get("agent", DEFAULT_AGENT)
+        model_raw = (
+            agent_cfg.get("model_name")
+            or raw.get("model_name")
+            or raw.get("model")
+        )
         # Model — keep provider prefix intact for downstream resolution
-        model = effective_model(agent_name, agent_cfg.get("model_name") or None)
+        model = effective_model(agent_name, model_raw)
 
         # Environment
         env_cfg = raw.get("environment", {})
@@ -353,6 +390,26 @@ class Job:
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
+        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        scenes_raw = raw.get("scenes")
+        scenes: list[Scene] | None
+        if scenes_raw is None:
+            scenes = None
+        elif not scenes_raw:
+            logger.warning(
+                "scenes: [] is empty — falling through to legacy single-turn execution. "
+                "Remove the key entirely if that is the intent."
+            )
+            scenes = None
+        else:
+            scenes = [parse_scene(s) for s in scenes_raw]
+
+        # Derive summary fields from scenes when present so summary.json reflects what runs.
+        if scenes and scenes[0].roles:
+            primary_role = scenes[0].roles[0]
+            agent_name = primary_role.agent
+            model = primary_role.model or model
+
         config = JobConfig(
             agent=agent_name,
             model=model,
@@ -364,6 +421,7 @@ class Job:
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
+            scenes=scenes,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -416,23 +474,39 @@ class Job:
         return skills_dir
 
     async def _run_single_task(self, task_dir: Path, cfg: JobConfig) -> RunResult:
-        """Execute one trial via Trial."""
+        """Execute one trial via Trial.
+
+        Uses cfg.scenes when present (multi-scene flow); otherwise synthesizes
+        a single Scene from the legacy agent/model/prompts so single-turn jobs
+        keep working unchanged.
+        """
         from benchflow.trial import Trial, TrialConfig
 
-        trial_config = TrialConfig.from_legacy(
+        resolved_skills = self._resolve_skills_dir(task_dir, cfg.skills_dir)
+        scenes = cfg.scenes or [
+            Scene.single(
+                agent=cfg.agent,
+                model=cfg.model,
+                prompts=cfg.prompts,
+                skills_dir=resolved_skills,
+            )
+        ]
+        trial_config = TrialConfig(
             task_path=task_dir,
-            agent=cfg.agent,
-            model=cfg.model,
-            prompts=cfg.prompts,
-            agent_env=cfg.agent_env,
+            scenes=scenes,
             job_name=self._job_name,
             jobs_dir=str(self._jobs_dir),
             environment=cfg.environment,
-            skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
             context_root=cfg.context_root,
+            agent_env=cfg.agent_env,
+            skills_dir=resolved_skills,
+            # Legacy mirror fields kept for any consumers reading them off TrialConfig:
+            agent=cfg.agent,
+            model=cfg.model,
+            prompts=cfg.prompts,
         )
         trial = await Trial.create(trial_config)
         return await trial.run()

--- a/src/benchflow/trial_yaml.py
+++ b/src/benchflow/trial_yaml.py
@@ -78,7 +78,7 @@ def trial_config_from_dict(
 
     # Scene-based format
     if "scenes" in raw:
-        scenes = [_parse_scene(s) for s in raw["scenes"]]
+        scenes = [parse_scene(s) for s in raw["scenes"]]
     elif "agent" in raw:
         # Legacy flat format
         prompts_raw = raw.get("prompts")
@@ -117,10 +117,10 @@ def trial_config_from_dict(
     )
 
 
-def _parse_scene(raw: dict) -> Scene:
+def parse_scene(raw: dict) -> Scene:
     """Parse a scene dict from YAML."""
-    roles = [_parse_role(r) for r in raw.get("roles", [])]
-    turns = [_parse_turn(t) for t in raw.get("turns", [])]
+    roles = [parse_role(r) for r in raw.get("roles", [])]
+    turns = [parse_turn(t) for t in raw.get("turns", [])]
 
     # If no turns specified but roles exist, create one turn per role
     if not turns and roles:
@@ -134,17 +134,17 @@ def _parse_scene(raw: dict) -> Scene:
     )
 
 
-def _parse_role(raw: dict) -> Role:
+def parse_role(raw: dict) -> Role:
     """Parse a role dict from YAML."""
     return Role(
         name=raw["name"],
         agent=raw["agent"],
-        model=raw.get("model"),
+        model=raw.get("model") or raw.get("model_name"),
         env=raw.get("env", {}),
     )
 
 
-def _parse_turn(raw: dict) -> Turn:
+def parse_turn(raw: dict) -> Turn:
     """Parse a turn dict from YAML."""
     return Turn(
         role=raw["role"],

--- a/tests/test_trial_yaml.py
+++ b/tests/test_trial_yaml.py
@@ -1,0 +1,21 @@
+"""Tests for trial YAML parsing helpers."""
+
+from benchflow.trial_yaml import parse_role
+
+
+def test_parse_role_model_name_fallback():
+    """Guards parse_role model_name fallback (issue #4 plan, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a", "model_name": "m"})
+    assert role.model == "m"
+
+
+def test_parse_role_model_takes_precedence():
+    """Guards parse_role precedence: model wins when both keys set (issue #4, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a", "model": "m1", "model_name": "m2"})
+    assert role.model == "m1"
+
+
+def test_parse_role_no_model_or_model_name():
+    """Guards parse_role None default (issue #4 plan, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a"})
+    assert role.model is None

--- a/tests/test_trial_yaml.py
+++ b/tests/test_trial_yaml.py
@@ -4,18 +4,18 @@ from benchflow.trial_yaml import parse_role
 
 
 def test_parse_role_model_name_fallback():
-    """Guards parse_role model_name fallback (issue #4 plan, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role accepts model_name as fallback for model (issue #4)."""
     role = parse_role({"name": "r", "agent": "a", "model_name": "m"})
     assert role.model == "m"
 
 
 def test_parse_role_model_takes_precedence():
-    """Guards parse_role precedence: model wins when both keys set (issue #4, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role prefers model over model_name when both are set (issue #4)."""
     role = parse_role({"name": "r", "agent": "a", "model": "m1", "model_name": "m2"})
     assert role.model == "m1"
 
 
 def test_parse_role_no_model_or_model_name():
-    """Guards parse_role None default (issue #4 plan, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role returns Role.model=None when neither key is set (issue #4)."""
     role = parse_role({"name": "r", "agent": "a"})
     assert role.model is None

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -374,7 +374,7 @@ def test_harbor_yaml_without_scenes_unchanged(harbor_yaml):
 
 
 def test_native_yaml_parses_top_level_scenes(tmp_path):
-    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (decision 1A, issue #4)."""
+    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -402,13 +402,13 @@ scenes:
 
 
 def test_native_yaml_without_scenes_unchanged(native_yaml):
-    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (decision 1A, issue #4)."""
+    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (issue #4)."""
     job = Job.from_yaml(native_yaml)
     assert job._config.scenes is None
 
 
 def test_harbor_yaml_top_level_singular_agent_and_model_name(tmp_path):
-    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (TODO 1, issue #4)."""
+    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -425,7 +425,7 @@ datasets:
 
 
 def test_harbor_yaml_empty_scenes_warns(tmp_path, caplog):
-    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (TODO 2, issue #4)."""
+    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -448,7 +448,7 @@ scenes: []
 
 
 def test_harbor_yaml_summary_fields_match_first_scene_role(tmp_path):
-    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (TODO 3, issue #4)."""
+    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -472,3 +472,157 @@ scenes:
     job = Job.from_yaml(config)
     assert job._config.agent == "pi-acp"
     assert job._config.model == "vllm/Qwen/Qwen3.6-27B"
+
+
+def test_harbor_yaml_oracle_role_keeps_model_none(tmp_path):
+    """Guards the fix from PR #5: scene-derived agent must re-resolve through effective_model so an oracle role does not inherit DEFAULT_MODEL from a non-oracle top-level (would otherwise make summary.json disagree with result.json)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+datasets:
+  - path: tasks
+scenes:
+  - name: verify
+    roles:
+      - name: checker
+        agent: oracle
+    turns:
+      - role: checker
+        prompt: "run solve.sh"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "oracle"
+    assert job._config.model is None
+
+
+def test_native_yaml_oracle_role_keeps_model_none(tmp_path):
+    """Guards the fix from PR #5: same oracle short-circuit as the Harbor parallel — the native loader carries a duplicate of the summary-field derivation block (issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+agent: pi-acp
+scenes:
+  - name: verify
+    roles:
+      - name: checker
+        agent: oracle
+    turns:
+      - role: checker
+        prompt: "run solve.sh"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "oracle"
+    assert job._config.model is None
+
+
+async def test_native_yaml_branch_passes_scenes_to_trial(tmp_path, monkeypatch):
+    """Guards the fix from PR #5: native loader's scenes-to-Trial wiring is verified end-to-end, mirroring the Harbor parallel — closes the duplicated-block coverage gap (issue #4)."""
+    task_dir = _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes:
+  - name: build
+    roles:
+      - name: builder
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: builder
+        prompt: "build it"
+  - name: verify
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    await job._run_single_task(task_dir, job._config)
+
+    captured = seen["config"]
+    assert captured.scenes == job._config.scenes
+    assert [s.name for s in captured.scenes] == ["build", "verify"]
+
+
+def test_native_yaml_empty_scenes_warns(tmp_path, caplog):
+    """Guards the fix from PR #5: native loader's scenes: [] warning matches Harbor (issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes: []
+""")
+
+    with caplog.at_level(logging.WARNING, logger="benchflow.job"):
+        job = Job.from_yaml(config)
+
+    assert job._config.scenes is None
+    assert any(
+        "scenes" in msg and "empty" in msg for msg in caplog.messages
+    ), f"Expected warning about empty scenes; got: {caplog.messages!r}"
+
+
+async def test_run_single_task_legacy_branch_synthesizes_single_scene(
+    tmp_path, monkeypatch
+):
+    """Guards the fix from PR #5: when cfg.scenes is None, _run_single_task must synthesize a single Scene from agent/model/prompts and pass it to Trial.create. The legacy single-turn path was previously TrialConfig.from_legacy(...); the refactor's correctness rides on this branch and existing job tests bypass it via the _sdk mock (issue #4)."""
+    from benchflow.job import JobConfig
+
+    task_dir = _make_task_dir(tmp_path)
+    job = Job(
+        tasks_dir=task_dir.parent,
+        jobs_dir=tmp_path / "out",
+        config=JobConfig(
+            agent="claude-agent-acp",
+            model="claude-haiku-4-5-20251001",
+            prompts=["do x", "review"],
+        ),
+    )
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    await job._run_single_task(task_dir, job._config)
+
+    captured = seen["config"]
+    assert len(captured.scenes) == 1
+    assert captured.scenes[0].roles[0].agent == "claude-agent-acp"
+    assert captured.scenes[0].roles[0].model == "claude-haiku-4-5-20251001"
+    assert [t.prompt for t in captured.scenes[0].turns] == ["do x", "review"]
+    # Legacy mirror fields on TrialConfig must round-trip the same values.
+    assert captured.agent == "claude-agent-acp"
+    assert captured.model == "claude-haiku-4-5-20251001"
+    assert captured.prompts == ["do x", "review"]

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,10 +1,13 @@
 """Tests for YAML job config loading."""
 
+import logging
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from benchflow.job import Job
+from benchflow.models import RunResult
 
 
 @pytest.fixture
@@ -259,3 +262,213 @@ sandbox_user: testuser
         assert job._config.agent_env == {}
         assert job._config.sandbox_user == "agent"
         assert job._config.sandbox_setup_timeout == 120
+
+
+# ── Scenes parsing (issue #4) ──
+
+
+def _make_task_dir(tmp_path: Path, name: str = "task-a") -> Path:
+    """Create a tasks/<name> directory with task.toml."""
+    task_dir = tmp_path / "tasks" / name
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('version = "1.0"')
+    return task_dir
+
+
+def test_harbor_yaml_parses_issue_4_repro(tmp_path):
+    """Guards the fix from commit 22f52b4 against the silent-scenes-drop regression in issue #4 — mirrors the literal repro YAML."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+model_name: vllm/Qwen/Qwen3.6-27B
+datasets:
+  - path: tasks
+scenes:
+  - name: build-skill
+    roles:
+      - name: builder
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: builder
+        prompt: "build the skill ..."
+  - name: answer
+    roles:
+      - name: solver
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+    scenes = job._config.scenes
+
+    assert scenes is not None
+    assert len(scenes) == 2
+    assert scenes[0].name == "build-skill"
+    assert scenes[0].roles[0].agent == "pi-acp"
+    assert scenes[0].roles[0].model == "vllm/Qwen/Qwen3.6-27B"
+    assert scenes[0].turns[0].prompt == "build the skill ..."
+    assert scenes[1].name == "answer"
+    assert scenes[1].turns[0].prompt is None
+
+
+async def test_harbor_yaml_branch_passes_scenes_to_trial(tmp_path, monkeypatch):
+    """Guards the fix from commit 22f52b4 against the bug where Harbor scenes never reached Trial — exercises the path that would have failed pre-fix (issue #4)."""
+    task_dir = _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+datasets:
+  - path: tasks
+scenes:
+  - name: build-skill
+    roles:
+      - name: builder
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: builder
+        prompt: "build it"
+  - name: answer
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    result = await job._run_single_task(task_dir, job._config)
+
+    assert result.rewards == {"reward": 1.0}
+    captured = seen["config"]
+    assert captured.scenes == job._config.scenes
+    assert [s.name for s in captured.scenes] == ["build-skill", "answer"]
+    assert len(captured.scenes[0].roles) == 1
+    assert len(captured.scenes[0].turns) == 1
+    assert len(captured.scenes[1].turns) == 1
+
+
+def test_harbor_yaml_without_scenes_unchanged(harbor_yaml):
+    """Guards commit 22f52b4: harbor YAML without scenes: still produces scenes=None (legacy single-turn path, issue #4)."""
+    job = Job.from_yaml(harbor_yaml)
+    assert job._config.scenes is None
+
+
+def test_native_yaml_parses_top_level_scenes(tmp_path):
+    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (decision 1A, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes:
+  - name: solve
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+        prompt: "solve it"
+""")
+
+    job = Job.from_yaml(config)
+    scenes = job._config.scenes
+
+    assert scenes is not None
+    assert len(scenes) == 1
+    assert scenes[0].name == "solve"
+    assert scenes[0].roles[0].agent == "claude-agent-acp"
+    assert scenes[0].turns[0].prompt == "solve it"
+
+
+def test_native_yaml_without_scenes_unchanged(native_yaml):
+    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (decision 1A, issue #4)."""
+    job = Job.from_yaml(native_yaml)
+    assert job._config.scenes is None
+
+
+def test_harbor_yaml_top_level_singular_agent_and_model_name(tmp_path):
+    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (TODO 1, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+model_name: vllm/Qwen/Qwen3.6-27B
+datasets:
+  - path: tasks
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "pi-acp"
+    assert job._config.model == "vllm/Qwen/Qwen3.6-27B"
+
+
+def test_harbor_yaml_empty_scenes_warns(tmp_path, caplog):
+    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (TODO 2, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: claude-agent-acp
+    model_name: claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+scenes: []
+""")
+
+    with caplog.at_level(logging.WARNING, logger="benchflow.job"):
+        job = Job.from_yaml(config)
+
+    assert job._config.scenes is None
+    assert any(
+        "scenes" in msg and "empty" in msg for msg in caplog.messages
+    ), f"Expected warning about empty scenes; got: {caplog.messages!r}"
+
+
+def test_harbor_yaml_summary_fields_match_first_scene_role(tmp_path):
+    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (TODO 3, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: claude-agent-acp
+    model_name: claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+scenes:
+  - name: solve
+    roles:
+      - name: solver
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: solver
+        prompt: "solve it"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "pi-acp"
+    assert job._config.model == "vllm/Qwen/Qwen3.6-27B"


### PR DESCRIPTION
## Summary

Implements [`plan/2026-04-26-issue-4-harbor-scenes-parsing.md`](plan/2026-04-26-issue-4-harbor-scenes-parsing.md). Closes #4.

`Job.from_yaml(...)` (Harbor branch, `_from_harbor_yaml`) silently dropped a top-level `scenes:` block — multi-turn intent vanished and every task ran single-turn. `JobConfig` had no `scenes` field, so the parsed value was discarded with no warning. This wires scenes through both Harbor and native loaders, adds Harbor's singular `agent:` / `model_name:` fallback so the issue #4 repro YAML round-trips correctly, and unifies `_run_single_task` on a single `TrialConfig(...)` call. Strictly additive — YAMLs without `scenes:` behave identically.

## Plan steps

- 5431cdd — refactor: promote `parse_scene` / `parse_role` / `parse_turn` + add `model_name` fallback
- 22f52b4 — feat: parse top-level scenes in `Job.from_yaml` (Harbor + native)
- ed04894 — test: regression coverage for Harbor scenes parsing (Tests A-H)

## Review status

| Review | Status | Notes |
|--------|--------|-------|
| Eng Review (`/plan-eng-review`) | CLEAR (PLAN) | 6 issues found, all 9 decisions captured; the critical gap (empty-scenes silent fall-through) was closed in-PR by the warn-on-`scenes: []` behavior |
| Spec compliance (per-task subagent) | PASS x3 | each commit verified line-by-line against the plan |
| Code quality (per-task subagent) | PASS x3 | minor notes (test name accuracy, redundant import) resolved in-band before commit |

## Test plan

- [x] `pytest tests/` — 704 passed, 1 skipped, 1 deselected (was 696; +8 in `test_yaml_config.py`, +3 in new `tests/test_trial_yaml.py`)
- [x] `ruff check` on all touched files — clean
- [x] `ty check src/benchflow/job.py src/benchflow/trial_yaml.py` — only the pre-existing diagnostic at `trial_yaml.py:95` (unrelated, in the legacy `Scene.single` call site)
- [x] Issue #4 repro YAML loaded via `Job.from_yaml`: `_config.scenes` is the 2-element list, `_config.agent == "pi-acp"`, `_config.model == "vllm/Qwen/Qwen3.6-27B"`

The load-bearing regression test is `tests/test_yaml_config.py::test_harbor_yaml_branch_passes_scenes_to_trial` — it monkeypatches `Trial.create` and asserts the captured `TrialConfig.scenes` equals `job._config.scenes`. This would have failed pre-fix (no `scenes` field on `JobConfig`).