### PR TITLE
fix: avoid double-deploying skills when skills_dir is set

### DIFF
--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -402,6 +402,8 @@ class Trial:
         if cfg.skills_dir:
             _inject_skills_into_dockerfile(effective_task_path, Path(cfg.skills_dir))
 
+        self._effective_task_path = effective_task_path
+
         self._env = _create_environment(
             cfg.environment,
             self._task,
@@ -474,7 +476,7 @@ class Trial:
             )
             await deploy_skills(
                 self._env,
-                cfg.task_path,
+                getattr(self, "_effective_task_path", cfg.task_path),
                 cfg.skills_dir,
                 None,
                 cfg.sandbox_user,
@@ -520,7 +522,7 @@ class Trial:
 
         await deploy_skills(
             self._env,
-            cfg.task_path,
+            getattr(self, "_effective_task_path", cfg.task_path),
             cfg.skills_dir,
             self._agent_cfg,
             cfg.sandbox_user,

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -92,6 +92,51 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_skips_runtime_upload_when_dockerfile_already_injected(
+    tmp_path,
+):
+    """Guards the fix from PR for issue #11 against the regression where
+    skills got deployed twice — once baked into the image via
+    `_inject_skills_into_dockerfile`, and again at runtime via
+    `env.upload_dir(..., "/skills")`. The runtime cp failed with
+    `cannot overwrite directory "/skills/<entry>" with non-directory "/skills"`
+    when the source contained a symlink colliding with a baked entry.
+
+    The detection works only when `deploy_skills` receives the *effective*
+    task path — the temp copy whose Dockerfile actually carries the
+    injected `COPY _deps/skills /skills/` line.
+    """
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+    agent_cfg = AgentConfig(
+        name="test-agent",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=["$HOME/.agents/skills"],
+    )
+    effective_task_path = tmp_path / "task"
+    (effective_task_path / "environment").mkdir(parents=True)
+    (effective_task_path / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12\nCOPY _deps/skills /skills/\n"
+    )
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    await deploy_skills(
+        env=env,
+        task_path=effective_task_path,
+        skills_dir=skills_dir,
+        agent_cfg=agent_cfg,
+        sandbox_user="agent",
+        agent_cwd="/workspace",
+        task=_make_task(None),
+    )
+
+    env.upload_dir.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_chowns_full_dir_chain_for_pi_acp_layout(tmp_path):
     """Guards the fix from PR #211 against the regression where only the
     symlink's immediate parent (`~/.pi/agent`) was chowned, leaving the


### PR DESCRIPTION
## Summary
- Fixes #11 — `deploy_skills` was receiving `cfg.task_path` (original) instead of the post-injection temp copy, so its `already_injected` check always read False and the runtime `env.upload_dir(..., "/skills")` fired on top of skills already baked into the image. With a colliding symlink in the source, the cp failed with `cannot overwrite directory "/skills/<entry>" with non-directory "/skills"`.
- Stash the post-injection path on `self._effective_task_path` in `Trial._setup` and pass it to both `deploy_skills` call sites (oracle + agent).
- Add a regression test in `tests/test_agent_setup.py` that writes a Dockerfile carrying the injected `COPY _deps/skills /skills/` line and asserts `env.upload_dir` is not called.

## Test plan
- [x] `pytest tests/test_agent_setup.py tests/test_trial_install_agent_timeout.py tests/test_env_setup.py tests/test_verify.py` — passes (81 tests).
- [x] `ruff check` clean.
- [x] `ty check src/` clean.
- [ ] Re-run reporter's InfiniteBench run with `skills_dir: auto` to confirm 16/16 trials succeed end-to-end.