### PR TITLE
Add openai + us-openai provider routing

### DIFF
--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -155,6 +155,18 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_env="AZURE_API_KEY",
         url_params={"resource": "AZURE_RESOURCE"},
     ),
+    # ── OpenAI first-party API ──
+    "openai": ProviderConfig(
+        name="openai",
+        base_url="https://api.openai.com/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="OPENAI_API_KEY",
+        endpoints={
+            "openai-completions": "https://api.openai.com/v1",
+            "openai-responses": "https://api.openai.com/v1",
+        },
+    ),
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
         name="vllm",

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -167,6 +167,19 @@ PROVIDERS: dict[str, ProviderConfig] = {
             "openai-responses": "https://api.openai.com/v1",
         },
     ),
+    # OpenAI US data-residency endpoint. Same key, regional URL.
+    "us-openai": ProviderConfig(
+        name="us-openai",
+        base_url="https://us.api.openai.com/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="OPENAI_API_KEY",
+        endpoints={
+            "openai-completions": "https://us.api.openai.com/v1",
+            "openai-responses": "https://us.api.openai.com/v1",
+        },
+    ),
+    # TODO: add eu-openai (https://eu.api.openai.com/v1) when needed.
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
         name="vllm",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -41,6 +41,16 @@ class TestFindProvider:
         assert name == "aws-bedrock"
         assert cfg.auth_type == "aws"
 
+    def test_openai_prefix(self):
+        """Guards the PR #158 follow-up fix for openai/... provider routing."""
+        name, cfg = find_provider("openai/gpt-5.4-mini")
+
+        assert name == "openai"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "OPENAI_API_KEY"
+        assert resolve_auth_env("openai/gpt-5.4-mini") == "OPENAI_API_KEY"
+        assert strip_provider_prefix("openai/gpt-5.4-mini") == "gpt-5.4-mini"
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [
@@ -106,6 +116,20 @@ class TestResolveBaseUrl:
             auth_env="ZAI_API_KEY",
         )
         assert resolve_base_url(p, {}) == "https://api.z.ai/api/paas/v4"
+
+    def test_openai_endpoints(self):
+        """Guards the PR #158 follow-up fix for first-party OpenAI endpoints."""
+        p = PROVIDERS["openai"]
+
+        assert resolve_base_url(p, {}) == "https://api.openai.com/v1"
+        assert (
+            resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://api.openai.com/v1"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
+            == "https://api.openai.com/v1"
+        )
 
     def test_project_id_expansion(self):
         p = ProviderConfig(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -51,6 +51,15 @@ class TestFindProvider:
         assert resolve_auth_env("openai/gpt-5.4-mini") == "OPENAI_API_KEY"
         assert strip_provider_prefix("openai/gpt-5.4-mini") == "gpt-5.4-mini"
 
+    def test_us_openai_prefix(self):
+        name, cfg = find_provider("us-openai/gpt-5.4-mini")
+
+        assert name == "us-openai"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "OPENAI_API_KEY"
+        assert resolve_auth_env("us-openai/gpt-5.4-mini") == "OPENAI_API_KEY"
+        assert strip_provider_prefix("us-openai/gpt-5.4-mini") == "gpt-5.4-mini"
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [
@@ -129,6 +138,19 @@ class TestResolveBaseUrl:
         assert (
             resolve_base_url(p, {}, protocol="openai-responses")
             == "https://api.openai.com/v1"
+        )
+
+    def test_us_openai_endpoints(self):
+        p = PROVIDERS["us-openai"]
+
+        assert resolve_base_url(p, {}) == "https://us.api.openai.com/v1"
+        assert (
+            resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://us.api.openai.com/v1"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
+            == "https://us.api.openai.com/v1"
         )
 
     def test_project_id_expansion(self):

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -282,6 +282,32 @@ class TestResolveProviderEnv:
         assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
         assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
 
+    def test_openai_provider_sets_pi_openai_completions_env(self):
+        """Guards PR #158 follow-up: pi-acp must not fallback to Anthropic for openai/...."""
+        env = {"OPENAI_API_KEY": "sk-test"}
+
+        resolve_provider_env(env, "openai/gpt-5.4-mini", "pi-acp")
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "openai"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "gpt-5.4-mini"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-completions"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-test"
+
+    def test_openai_provider_sets_codex_responses_env(self):
+        """Guards PR #158 follow-up: codex-acp must use Responses for openai/... models."""
+        env = {"OPENAI_API_KEY": "sk-test"}
+
+        resolve_provider_env(env, "openai/gpt-5.4-mini", "codex-acp")
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "openai"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "gpt-5.4-mini"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-test"
+        assert env["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["OPENAI_API_KEY"] == "sk-test"
+
     def test_azure_foundry_openai_maps_to_codex_env(self):
         env = {
             "AZURE_API_KEY": "az-test",


### PR DESCRIPTION
## Summary
- Register first-party `openai` provider so `model: openai/<id>` routes correctly (was silently falling back to unauthenticated Anthropic).
- Add `us-openai` provider for the US data-residency endpoint (`https://us.api.openai.com/v1`), reusing `OPENAI_API_KEY`.
- Expose both `openai-completions` and `openai-responses` endpoint variants on each.
- TODO comment left in the registry for `eu-openai` when needed.

## Root cause
`openai/<model>` looked provider-prefixed, but `openai` was not in `PROVIDERS`. BenchFlow skipped `BENCHFLOW_PROVIDER_*` injection, and pi-acp (and any launcher mirroring its conditional) fell through to the Anthropic env path — producing zero-tool-call trials with no error surfaced. See `benchflow-no-openai-provider.md` for the full repro trail.

## What changes for users
- `model: openai/gpt-5.4-mini` — routes to `api.openai.com` with `OPENAI_API_KEY`.
- `model: us-openai/gpt-5.4-mini` — routes to `us.api.openai.com` with the same key.

## Validation
- `uv run pytest tests/test_providers.py tests/test_resolve_env_helpers.py tests/test_pi_acp_launcher.py tests/test_registry_invariants.py tests/test_agent_registry.py -q`
- `uv run ruff check src/benchflow/agents/providers.py tests/test_providers.py tests/test_resolve_env_helpers.py`
- `uv run ty check src/benchflow/agents/providers.py src/benchflow/agents/env.py`